### PR TITLE
feat: Implement basic Room database setup

### DIFF
--- a/app/src/main/java/com/tomatomediacenter/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/tomatomediacenter/data/db/AppDatabase.kt
@@ -1,0 +1,39 @@
+package com.tomatomediacenter.data.db
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.tomatomediacenter.data.db.dao.PlaceholderDao
+import com.tomatomediacenter.data.db.entity.PlaceholderEntity
+
+@Database(
+    entities = [PlaceholderEntity::class],
+    version = 1,
+    exportSchema = true // It's good practice to export schema for migrations
+)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun placeholderDao(): PlaceholderDao
+
+    // You can add a companion object for singleton instantiation if not using DI,
+    // but since DI is likely (due to the 'di' package), I'll omit it for now.
+    // If DI is not used, a typical singleton pattern would be:
+    /*
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        fun getDatabase(context: android.content.Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                val instance = Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "app_database" // Database file name
+                )
+                // Add migrations here if needed
+                .build()
+                INSTANCE = instance
+                instance
+            }
+        }
+    }
+    */
+}

--- a/app/src/main/java/com/tomatomediacenter/data/db/dao/PlaceholderDao.kt
+++ b/app/src/main/java/com/tomatomediacenter/data/db/dao/PlaceholderDao.kt
@@ -1,0 +1,31 @@
+package com.tomatomediacenter.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.tomatomediacenter.data.db.entity.PlaceholderEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PlaceholderDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(placeholder: PlaceholderEntity): Long
+
+    @Query("SELECT * FROM placeholders WHERE id = :id")
+    fun getById(id: Int): Flow<PlaceholderEntity?>
+
+    @Query("SELECT * FROM placeholders ORDER BY name ASC")
+    fun getAll(): Flow<List<PlaceholderEntity>>
+
+    @Update
+    suspend fun update(placeholder: PlaceholderEntity)
+
+    @Delete
+    suspend fun delete(placeholder: PlaceholderEntity)
+
+    @Query("DELETE FROM placeholders")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/tomatomediacenter/data/db/entity/PlaceholderEntity.kt
+++ b/app/src/main/java/com/tomatomediacenter/data/db/entity/PlaceholderEntity.kt
@@ -1,0 +1,11 @@
+package com.tomatomediacenter.data.db.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "placeholders")
+data class PlaceholderEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int = 0,
+    val name: String
+)

--- a/app/src/main/java/com/tomatomediacenter/di/DatabaseModule.kt
+++ b/app/src/main/java/com/tomatomediacenter/di/DatabaseModule.kt
@@ -1,0 +1,36 @@
+package com.tomatomediacenter.di
+
+import android.content.Context
+import androidx.room.Room
+import com.tomatomediacenter.data.db.AppDatabase
+import com.tomatomediacenter.data.db.dao.PlaceholderDao
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+
+    @Provides
+    @Singleton
+    fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase {
+        return Room.databaseBuilder(
+            context.applicationContext,
+            AppDatabase::class.java,
+            "app_database" // Ensure this matches the name used if manually instantiating
+        )
+        // In a real app, you'd add .addMigrations(...) here if you have migrations
+        // .fallbackToDestructiveMigration() // Or this, for development/testing if you don't want to write migrations yet
+        .build()
+    }
+
+    @Provides
+    @Singleton // DAOs are usually singletons within the scope of the database
+    fun providePlaceholderDao(appDatabase: AppDatabase): PlaceholderDao {
+        return appDatabase.placeholderDao()
+    }
+}


### PR DESCRIPTION
This commit introduces the foundational setup for Room database.

Key changes include:
- Defined a placeholder `PlaceholderEntity` for demonstration.
- Implemented `PlaceholderDao` with basic CRUD operations.
- Created the `AppDatabase` class, version 1, with schema export enabled.
- Added `DatabaseModule` for Hilt to provide `AppDatabase` and `PlaceholderDao` instances.

Room dependencies were confirmed to be already present. The schema will be generated by Room, and migrations can be added in the future by incrementing the database version and providing migration paths.