### PR TITLE
feat: Implement Material Design 3 UI Foundation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,8 +70,10 @@ dependencies {
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
+    implementation("androidx.compose.material3:material3:1.2.1")
     implementation(libs.compose.material.icons.extended)
     implementation(libs.compose.navigation)
+    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation(libs.compose.hilt.navigation)
     implementation(libs.compose.animation)
 

--- a/app/src/main/java/com/tomatomediacenter/MainActivity.kt
+++ b/app/src/main/java/com/tomatomediacenter/MainActivity.kt
@@ -1,0 +1,18 @@
+package com.tomatomediacenter
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import com.tomatomediacenter.ui.navigation.AppNavigation
+import com.tomatomediacenter.ui.theme.TomatoMediaCenterTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TomatoMediaCenterTheme {
+                AppNavigation()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/tomatomediacenter/ui/components/Button.kt
+++ b/app/src/main/java/com/tomatomediacenter/ui/components/Button.kt
@@ -1,0 +1,23 @@
+package com.tomatomediacenter.ui.components
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.tomatomediacenter.ui.theme.TomatoMediaCenterTheme
+
+@Composable
+fun AppButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    text: String
+) {
+    TomatoMediaCenterTheme {
+        Button(
+            onClick = onClick,
+            modifier = modifier
+        ) {
+            Text(text = text)
+        }
+    }
+}

--- a/app/src/main/java/com/tomatomediacenter/ui/components/Card.kt
+++ b/app/src/main/java/com/tomatomediacenter/ui/components/Card.kt
@@ -1,0 +1,20 @@
+package com.tomatomediacenter.ui.components
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material3.Card
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.tomatomediacenter.ui.theme.TomatoMediaCenterTheme
+
+@Composable
+fun AppCard(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    TomatoMediaCenterTheme {
+        Card(
+            modifier = modifier,
+            content = content
+        )
+    }
+}

--- a/app/src/main/java/com/tomatomediacenter/ui/components/TextField.kt
+++ b/app/src/main/java/com/tomatomediacenter/ui/components/TextField.kt
@@ -1,0 +1,28 @@
+package com.tomatomediacenter.ui.components
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.tomatomediacenter.ui.theme.TomatoMediaCenterTheme
+
+@Composable
+fun AppTextField(
+    modifier: Modifier = Modifier,
+    label: String,
+    initialValue: String = ""
+) {
+    TomatoMediaCenterTheme {
+        var text by remember { mutableStateOf(initialValue) }
+        TextField(
+            value = text,
+            onValueChange = { text = it },
+            label = { Text(label) },
+            modifier = modifier
+        )
+    }
+}

--- a/app/src/main/java/com/tomatomediacenter/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/tomatomediacenter/ui/navigation/Navigation.kt
@@ -1,0 +1,39 @@
+package com.tomatomediacenter.ui.navigation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+sealed class Screen(val route: String) {
+    object HomeScreen : Screen("home_screen")
+}
+
+@Composable
+fun AppNavigation() {
+    val navController = rememberNavController()
+    NavHost(navController = navController, startDestination = Screen.HomeScreen.route) {
+        composable(Screen.HomeScreen.route) {
+            HomeScreen()
+        }
+        // Add other composables/screens here
+    }
+}
+
+@Composable
+fun HomeScreen() {
+    // Placeholder HomeScreen content
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Home Screen")
+    }
+}

--- a/app/src/main/java/com/tomatomediacenter/ui/theme/Color.kt
+++ b/app/src/main/java/com/tomatomediacenter/ui/theme/Color.kt
@@ -1,0 +1,11 @@
+package com.tomatomediacenter.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple80 = Color(0xFFD0BCFF)
+val PurpleGrey80 = Color(0xFFCCC2DC)
+val Pink80 = Color(0xFFEFB8C8)
+
+val Purple40 = Color(0xFF6650a4)
+val PurpleGrey40 = Color(0xFF625b71)
+val Pink40 = Color(0xFF7D5260)

--- a/app/src/main/java/com/tomatomediacenter/ui/theme/Theme.kt
+++ b/app/src/main/java/com/tomatomediacenter/ui/theme/Theme.kt
@@ -1,0 +1,70 @@
+package com.tomatomediacenter.ui.theme
+
+import android.app.Activity
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Purple80,
+    secondary = PurpleGrey80,
+    tertiary = Pink80
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    tertiary = Pink40
+
+    /* Other default colors to override
+    background = Color(0xFFFFFBFE),
+    surface = Color(0xFFFFFBFE),
+    onPrimary = Color.White,
+    onSecondary = Color.White,
+    onTertiary = Color.White,
+    onBackground = Color(0xFF1C1B1F),
+    onSurface = Color(0xFF1C1B1F),
+    */
+)
+
+@Composable
+fun TomatoMediaCenterTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    // Dynamic color is available on Android 12+
+    dynamicColor: Boolean = true,
+    content: @Composable () -> Unit
+) {
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+        }
+
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colorScheme.primary.toArgb()
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/app/src/main/java/com/tomatomediacenter/ui/theme/Typography.kt
+++ b/app/src/main/java/com/tomatomediacenter/ui/theme/Typography.kt
@@ -1,0 +1,34 @@
+package com.tomatomediacenter.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+// Set of Material typography styles to start with
+val Typography = Typography(
+    bodyLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 16.sp,
+        lineHeight = 24.sp,
+        letterSpacing = 0.5.sp
+    )
+    /* Other default text styles to override
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+        letterSpacing = 0.sp
+    ),
+    labelSmall = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Medium,
+        fontSize = 11.sp,
+        lineHeight = 16.sp,
+        letterSpacing = 0.5.sp
+    )
+    */
+)


### PR DESCRIPTION
This commit establishes the foundational UI layer for the application using Jetpack Compose and Material Design 3.

Key changes include:

- **Material Design 3 Theme:**
    - Added Material 3 dependencies.
    - Created `Color.kt`, `Typography.kt`, and `Theme.kt` (as `TomatoMediaCenterTheme`) to define the application's visual style.
- **Base Compose Components:**
    - Created a `components` package (`com.tomatomediacenter.ui.components`).
    - Added basic Material 3 versions of `Button`, `Card`, and `TextField`.
- **Navigation Setup:**
    - Added Jetpack Navigation Compose dependencies.
    - Created `Navigation.kt` (`com.tomatomediacenter.ui.navigation`) with `AppNavigation` NavHost and a sample `HomeScreen`.
- **Application Entry Point:**
    - Created/Updated `MainActivity.kt` to use `TomatoMediaCenterTheme` and `AppNavigation`.

This provides a solid base for future UI development and feature implementation.